### PR TITLE
Do not enumerate remote files which are in our ignore list

### DIFF
--- a/modules/sync-helper.js
+++ b/modules/sync-helper.js
@@ -34,7 +34,10 @@ var listRemoteFiles = function(remotePath, callback, originalRemotePath) {
 		remoteFiles.forEach(function(fileInfo) {
 			if(fileInfo.name == "." || fileInfo.name == "..") return;
 			var remoteItemPath = upath.toUnix(path.join(remotePath, fileInfo.name));
-			if(fileInfo.type != 'd')
+			if(isIgnored(ftpConfig.ignore, remoteItemPath)) {
+                return;
+            }
+            if(fileInfo.type != 'd')
 				result.push({ 
 					name: remoteItemPath, 
 					size: fileInfo.size,


### PR DESCRIPTION
## Issue
Current functionality lists all files recursively, even if a given directory or file is in our ignore list. This is wasted time. One great example of this is if I want to ignore node_modules on my remote server, currently it walks a huge list with FTP calls out for each one. This is potentially hundreds of calls.

## Proposed solution
If the file matches our ignore conditions when we're enumerating remote files, don't push it into our results or subdir list. This will avoid walking the chain. 

## Additional comments
With the change I've included in the PR, I went from being able to list and pull my remote files for a small (<20 user file node app, with a few dozen node modules) in 5 minutes to literally seconds. Very nice performance improvement.

(btw, love this extension! :+1: )