### PR TITLE
Map local to remote directories. (specific upload locations)

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
 	var syncCommand = vscode.commands.registerCommand('extension.ftpsyncupload', function() { require('./modules/sync-command')(true, getSyncHelper) });
 	var downloadCommand = vscode.commands.registerCommand('extension.ftpsyncdownload', function() { require('./modules/sync-command')(false, getSyncHelper) });
 	var commitCommand = vscode.commands.registerCommand('extension.ftpsynccommit', function() { require('./modules/commit-command')(getSyncHelper) });
+    var configCommand = vscode.commands.registerCommand('extension.ftpsyncconfig', require('./modules/open-config'));
 	
 	var onSave = require('./modules/on-save');
 	vscode.workspace.onDidSaveTextDocument(function(file) {
@@ -40,6 +41,7 @@ function activate(context) {
 	context.subscriptions.push(syncCommand);
 	context.subscriptions.push(downloadCommand);
 	context.subscriptions.push(commitCommand);
+    context.subscriptions.push(configCommand);
 }
 
 exports.activate = activate;

--- a/modules/directory-mapper.js
+++ b/modules/directory-mapper.js
@@ -1,0 +1,34 @@
+var vscode = require('vscode');
+var ftpconfig = require('./ftp-config');
+var path = require("path");
+var fs = require("fs");
+
+module.exports = {
+    
+    getMap: function () {
+        return ftpconfig.getConfig().directorymap;
+    },
+    
+    // Replaces remote path if there is a mapping specified for it.
+    getRemotePath: function(remotePath) {
+        
+        if (path.relative(vscode.workspace.rootPath, remotePath) != remotePath) {
+            var p_path = path.parse(path.join(vscode.workspace.rootPath, remotePath));
+        } else {
+            var p_path = path.parse(path.join(vscode.workspace.rootPath, path.relative(vscode.workspace.rootPath, remotePath)));
+        }
+        
+        // Keep in mind that remotePath is based on our relative workspace path
+        if (fs.lstatSync(path.format(p_path)).isDirectory()) {
+            var newPath = ftpconfig.getConfig().directorymap[remotePath];
+            return (newPath !== undefined)? newPath:remotePath;
+        } else {
+            var newDir = ftpconfig.getConfig().directorymap[path.relative(vscode.workspace.rootPath, p_path.dir)];
+            if (newDir !== undefined) {
+                return path.join(newDir, p_path.base);
+            }
+        }
+        return remotePath;        
+    }
+    
+}

--- a/modules/ftp-config.js
+++ b/modules/ftp-config.js
@@ -23,7 +23,8 @@ module.exports = {
         passive: false,
         debug: false,
         privateKeyPath: null,
-		ignore: ["\\.vscode","\\.git"]
+		ignore: ["\\.vscode","\\.git"],
+        directorymap:{ "":"" }
 	},
 	getConfig: function() {
 		var configjson = fs.readFileSync(this.getConfigPath()).toString();

--- a/modules/ftp-wrapper.js
+++ b/modules/ftp-wrapper.js
@@ -54,8 +54,8 @@ module.exports = function() {
         ftp.put(local, remote, callback)
     }
     
-    self.mkdir = function(path, callback) {
-        ftp.mkdir(path, callback)
+    self.mkdir = function(path, recursive, callback) {
+        ftp.mkdir(path, recursive, callback)
     }
     
     self.delete = function(path, callback) {

--- a/modules/open-config.js
+++ b/modules/open-config.js
@@ -1,0 +1,11 @@
+var vscode = require('vscode');
+var ftpconfig = require('./ftp-config');
+
+module.exports = function () {
+    if(!ftpconfig.validateConfig())
+		return;
+    
+    vscode.workspace.openTextDocument(ftpconfig.getConfigPath()).then(document => {
+			vscode.window.showTextDocument(document);
+    });
+}

--- a/modules/sync-command.js
+++ b/modules/sync-command.js
@@ -4,6 +4,7 @@ var ftpconfig = require('./ftp-config');
 var dirpick = require('./dirpick');
 var path = require('path');
 var helper = require('./command-helper');
+var directoryMapper = require("./directory-mapper");
 
 module.exports = function(isUpload, getSyncHelper) {
 	
@@ -84,7 +85,8 @@ module.exports = function(isUpload, getSyncHelper) {
 	}
 	
 	var prepareoptions = function(dirPath) {
-		
+        var remoteDirPath = directoryMapper.getRemotePath(dirPath);
+        
 		var pickResult = vscode.window.showQuickPick([{
 			label: "Full-sync",
 			description: "Removes orphan files on " + (isUpload ? "remote" : "local"),
@@ -102,7 +104,7 @@ module.exports = function(isUpload, getSyncHelper) {
 		pickResult.then(function(result) {
 			if(!result) return;
 			var syncOptions = {
-				remotePath: path.join(getSyncHelper().getConfig().remote, dirPath),
+				remotePath: path.join(getSyncHelper().getConfig().remote, remoteDirPath),
 				localPath: path.join(vscode.workspace.rootPath, dirPath),
 				upload: isUpload,
 				mode: result.mode

--- a/modules/sync-helper.js
+++ b/modules/sync-helper.js
@@ -206,8 +206,7 @@ var prepareSync = function(options, callback) {
 		if(err) callback(err);
 		else listRemoteFiles(options.remotePath, function(err, remoteFiles) {
 			if(err) {
-                if(err.code == 450) { // if main directory has to be created
-                    // Todo: check if directory is missing
+                if(err.code == 450) {
                     options.createTargetDirectory = true;
                 } else {
                     callback(err);

--- a/modules/sync-helper.js
+++ b/modules/sync-helper.js
@@ -8,6 +8,7 @@ var isIgnored = require('./is-ignored');
 var output = require("./output");
 var FtpWrapper = require("./ftp-wrapper");
 var SftpWrapper = require("./sftp-wrapper");
+var directoryMapper = require("./directory-mapper");
 
 var ftp;
 
@@ -18,9 +19,9 @@ var listRemoteFiles = function(remotePath, callback, originalRemotePath) {
 		originalRemotePath = remotePath;
 	ftp.list(remotePath, function(err, remoteFiles) {
 		if(err) { 
-			if(err.code == 450)
-				callback(null, []);
-			else
+            if(err.code == 450)
+				callback(err, []);
+            else
 				callback(err); 
 			return; 
 		}
@@ -117,7 +118,8 @@ var prepareSyncObject = function(remoteFiles, localFiles, options, callback) {
 	var dirsToAdd = [];
 	var filesToRemove = [];
 	var dirsToRemove = [];
-	
+    var createTargetDirectory = (options.createTargetDirectory !== undefined)? options.createTargetDirectory:false;
+    
 	if(options.mode == "force")
 		from.forEach(function(fromFile) {
 			var toEquivalent = to.find(function(toFile) { return toFile.name == fromFile.name });
@@ -148,7 +150,7 @@ var prepareSyncObject = function(remoteFiles, localFiles, options, callback) {
 				else
 					filesToRemove.push(toFile.name);
 			});
-
+            
 	callback(null, {
 		_readMe: "Review list of sync operations, then use Ftp-sync: Commit command to accept changes",
         _warning: "This file should not be saved, reopened review file won't work!",
@@ -156,7 +158,8 @@ var prepareSyncObject = function(remoteFiles, localFiles, options, callback) {
 		filesToAdd: filesToAdd,
 		dirsToAdd: dirsToAdd, 
 		filesToRemove: filesToRemove,
-		dirsToRemove: dirsToRemove
+		dirsToRemove: dirsToRemove,
+        createTargetDirectory: createTargetDirectory
 	});
 }
 
@@ -198,11 +201,20 @@ var connect = function(callback) {
 
 var prepareSync = function(options, callback) {
     output("[sync-helper] prepareSync");
+    
 	connect(function(err) {
 		if(err) callback(err);
 		else listRemoteFiles(options.remotePath, function(err, remoteFiles) {
-			if(err) callback(err);
-			else listLocalFiles(options.localPath, function(err, localFiles) {
+			if(err) {
+                if(err.code == 450) { // if main directory has to be created
+                    // Todo: check if directory is missing
+                    options.createTargetDirectory = true;
+                } else {
+                    callback(err);
+                    return
+                }
+            }
+			listLocalFiles(options.localPath, function(err, localFiles) {
 				if(err) callback(err);
 				else prepareSyncObject(remoteFiles, localFiles, options, callback);
 			})
@@ -266,7 +278,7 @@ var executeSyncRemote = function(sync, options, callback) {
 			if(err) callback(err); else executeSyncRemote(sync, options, callback);
 		});
 	}
-	
+    
 	if(sync.dirsToAdd.length > 0) {
 		var dirToAdd = sync.dirsToAdd.shift();	
 		var remotePath = upath.toUnix(path.join(options.remotePath, dirToAdd));
@@ -314,7 +326,9 @@ var ensureDirExists = function(remoteDir, callback) {
 
 var uploadFile = function(localPath, rootPath, callback) {
     output("[sync-helper] uploadFile");
-	var remotePath = upath.toUnix(path.join(ftpConfig.remote, localPath.replace(rootPath, '')));
+	var remotePath = upath.toUnix(
+            path.join(ftpConfig.remote, directoryMapper.getRemotePath(path.relative(rootPath, localPath)))
+        );
 	var remoteDir = upath.toUnix(path.dirname(remotePath));
 	connect(function(err) {
         if(err) callback(err);
@@ -338,9 +352,14 @@ var executeSync = function(sync, options, callback) {
 	sync.startTotal = totalOperations(sync);
 	connect(function(err) {
 		if(err) callback(err);
-		else if(options.upload) 
+		else if(options.upload)  {
+            if (sync.createTargetDirectory) {
+                ftp.mkdir(upath.toUnix(options.remotePath), true, function(err) {
+                    if(err) callback(err); else executeSyncRemote(sync, options, callback);
+                });
+            }
 			executeSyncRemote(sync, options, callback);
-		else
+        } else
 			executeSyncLocal(sync, options, callback);
 	});
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "onCommand:extension.ftpsyncupload",
     "onCommand:extension.ftpsyncdownload",
     "onCommand:extension.ftpsynccommit",
+    "onCommand:extension.ftpsyncconfig",
     "workspaceContains:.vscode/ftp-sync.json"
   ],
   "main": "./extension",
@@ -44,6 +45,10 @@
       {
         "command": "extension.ftpsynccommit",
         "title": "Ftp-sync: Commit"
+      },
+      {
+        "command": "extension.ftpsyncconfig",
+        "title": "Ftp-sync: Open config"
       }
     ]
   },


### PR DESCRIPTION
Hey, I added support to map local directories to remote directories.

For example, if I have a folder **build** and I want it to upload to my remote index instead of a build folder I'd do:

```
"directorymap": {
        "build": ""
    }
```

If I'd want to map my local **test** folder to a remote **beta** folder, i can do:

```
"directorymap": {
        "test": "beta"
    }
```

When you select _local to remote_ and then directory _test_ it will automatically upload to folder _beta_ instead of _test_ if this is specified in the _directorymap_
