### PR TITLE
Do not convert ignore Regexp to Unix path

### DIFF
--- a/modules/is-ignored.js
+++ b/modules/is-ignored.js
@@ -2,9 +2,6 @@ var upath = require("upath");
 
 module.exports = function(patterns, path) {
     path = upath.toUnix(path);
-    patterns = patterns.map(function(p) {
-        return upath.toUnix(p);
-    });
     
     var skip = false;
     patterns.forEach(function(pattern) {


### PR DESCRIPTION
`Regex != glob`

If you want to use a wildcard, then `Regexp` is not the right class...

Fixes #55 by using the `.*\\/\\.git` JSON value.
