### PR TITLE
Stop dropping the passphrase from config

### DIFF
--- a/modules/ftp-config.js
+++ b/modules/ftp-config.js
@@ -51,6 +51,7 @@ module.exports = {
 			port: config.port,
 			user: config.username,
 			password: config.password,
+			passphrase: config.passphrase,
 			ignore: config.ignore,
             passive: config.passive,
             protocol: config.protocol || "ftp",


### PR DESCRIPTION
The getSyncConfig would drop the passphrase parameter from the config object. So if the SSH key was encrypted, it would not be able to use the passphrase to decrypt it