### PR TITLE
Single-file upload

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -29,7 +29,8 @@ function activate(context) {
 	var syncCommand = vscode.commands.registerCommand('extension.ftpsyncupload', function() { require('./modules/sync-command')(true, getSyncHelper) });
 	var downloadCommand = vscode.commands.registerCommand('extension.ftpsyncdownload', function() { require('./modules/sync-command')(false, getSyncHelper) });
 	var commitCommand = vscode.commands.registerCommand('extension.ftpsynccommit', function() { require('./modules/commit-command')(getSyncHelper) });
-	
+	var uploadcurrentCommand = vscode.commands.registerCommand("extension.ftpsyncuploadselected", function(fileUrl) { require('./modules/uploadcurrent-command')(fileUrl, getSyncHelper) });
+
 	var onSave = require('./modules/on-save');
 	vscode.workspace.onDidSaveTextDocument(function(file) {
 		onSave(file, getSyncHelper);
@@ -40,6 +41,7 @@ function activate(context) {
 	context.subscriptions.push(syncCommand);
 	context.subscriptions.push(downloadCommand);
 	context.subscriptions.push(commitCommand);
+	context.subscriptions.push(uploadcurrentCommand);
 }
 
 exports.activate = activate;

--- a/modules/uploadcurrent-command.js
+++ b/modules/uploadcurrent-command.js
@@ -1,0 +1,34 @@
+/* global STATUS_TIMEOUT */
+var vscode = require("vscode");
+var ftpconfig = require("./ftp-config");
+var path = require("path");
+var isIgnored = require("./is-ignored");
+
+module.exports = function(fileUrl, getFtpSync) {
+	if(!vscode.workspace.rootPath) {
+		vscode.window.showErrorMessage("Ftp-sync: Cannot init ftp-sync without opened folder");
+		return;
+	}
+
+	if(fileUrl.fsPath.indexOf(vscode.workspace.rootPath) < 0) {
+		vscode.window.showErrorMessage("Ftp-sync: Selected file is not a part of the workspace.");
+		return;
+	}
+
+	var config = ftpconfig.getConfig();
+	if(isIgnored(config.ignore, fileUrl.fsPath)) {
+		vscode.window.showErrorMessage("Ftp-sync: Selected file is ignored.");
+		return;
+	}
+
+	var fileName = path.basename(fileUrl.fsPath);
+	var uploadingStatus = vscode.window.setStatusBarMessage("Ftp-sync: Uploading " + fileName + " to FTP server...");
+
+	getFtpSync().uploadFile(fileUrl.fsPath, vscode.workspace.rootPath, function(err) {
+		uploadingStatus.dispose();
+		if(err)
+			vscode.window.showErrorMessage("Ftp-sync: Uploading " + fileName + " failed: " + err);
+		else
+			vscode.window.setStatusBarMessage("Ftp-sync: " + fileName + " uploaded successfully!", STATUS_TIMEOUT);
+	})
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "onCommand:extension.ftpsyncupload",
     "onCommand:extension.ftpsyncdownload",
     "onCommand:extension.ftpsynccommit",
+    "onCommand:extension.ftpsyncuploadselected",
     "workspaceContains:.vscode/ftp-sync.json"
   ],
   "main": "./extension",
@@ -44,8 +45,20 @@
       {
         "command": "extension.ftpsynccommit",
         "title": "Ftp-sync: Commit"
-      }
-    ]
+      },
+			{
+				"command": "extension.ftpsyncuploadselected",
+				"title": "Ftp-sync: Upload File"
+			}
+    ],
+		"menus": {
+			"explorer/context": [
+				{
+					"command": "extension.ftpsyncuploadselected",
+					"group": "extension"
+				}
+			]
+		}
   },
   "devDependencies": {
     "vscode": "0.10.x"

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
         "command": "extension.ftpsynccommit",
         "title": "Ftp-sync: Commit"
       },
-			{
-				"command": "extension.ftpsyncuploadselected",
-				"title": "Ftp-sync: Upload File"
-			}
+      {
+        "command": "extension.ftpsyncuploadselected",
+        "title": "Ftp-sync: Upload File"
+      }
     ],
     "menus": {
       "explorer/context": [

--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
 				"title": "Ftp-sync: Upload File"
 			}
     ],
-		"menus": {
-			"explorer/context": [
-				{
-					"command": "extension.ftpsyncuploadselected",
-					"group": "extension"
-				}
-			]
-		}
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "extension.ftpsyncuploadselected",
+          "group": "extension"
+        }
+      ]
+    }
   },
   "devDependencies": {
     "vscode": "0.10.x"


### PR DESCRIPTION
I added a context-item (right click on the file in the sidebar) that will allow the user to upload a single file (sometimes useful with images and other non-editable assets), also proposed in this issue: [#53](https://github.com/lukasz-wronski/vscode-ftp-sync/issues/53)

The code is basically a clone of the [on-save.js](https://github.com/lukasz-wronski/vscode-ftp-sync/blob/master/modules/on-save.js) module, it does all the same checks.

PS. i'm aware of the similarity with this other pull request [#77](https://github.com/lukasz-wronski/vscode-ftp-sync/pull/77), but i find that not having to open a file to upload it could be a more viable solution in some contexts.
PPS. i'm also probably going to add other context menu items like upload a directory or download from remote to single files/directories which are features that i need/use all the time in other IDEs