### PR TITLE
Single-File Upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This extension allows you to easily synchronise your local workspace (project fi
 ## Usage
 There are four commands available. You can access them from the command palette (Ctrl+Shift+P on Windows/Linux).
 
+You can also upload a single file by right-clicking on it in the left menu and choosing the "Ftp-sync: Upload File" command.
+
 ### Ftp-sync: Init
 Initializes a default FTP-Sync configuration file in the `.vscode` directory. Options can be customised as follows:
 

--- a/extension.js
+++ b/extension.js
@@ -30,18 +30,19 @@ function activate(context) {
 	var downloadCommand = vscode.commands.registerCommand('extension.ftpsyncdownload', function() { require('./modules/sync-command')(false, getSyncHelper) });
 	var commitCommand = vscode.commands.registerCommand('extension.ftpsynccommit', function() { require('./modules/commit-command')(getSyncHelper) });
 	var singleCommand = vscode.commands.registerTextEditorCommand('extension.ftpsyncsingle', function(editor) { require('./modules/sync-single-command')(editor, getSyncHelper) });
-	
+	var uploadcurrentCommand = vscode.commands.registerCommand("extension.ftpsyncuploadselected", function(fileUrl) { require('./modules/uploadcurrent-command')(fileUrl, getSyncHelper) });
+
 	var onSave = require('./modules/on-save');
 	vscode.workspace.onDidSaveTextDocument(function(file) {
 		onSave(file, getSyncHelper);
 	});
-	
 	
 	context.subscriptions.push(initCommand);
 	context.subscriptions.push(syncCommand);
 	context.subscriptions.push(downloadCommand);
 	context.subscriptions.push(commitCommand);
 	context.subscriptions.push(singleCommand);
+	context.subscriptions.push(uploadcurrentCommand);
 }
 
 exports.activate = activate;

--- a/modules/uploadcurrent-command.js
+++ b/modules/uploadcurrent-command.js
@@ -1,0 +1,34 @@
+/* global STATUS_TIMEOUT */
+var vscode = require("vscode");
+var ftpconfig = require("./ftp-config");
+var path = require("path");
+var isIgnored = require("./is-ignored");
+
+module.exports = function(fileUrl, getFtpSync) {
+	if(!vscode.workspace.rootPath) {
+		vscode.window.showErrorMessage("Ftp-sync: Cannot init ftp-sync without opened folder");
+		return;
+	}
+
+	if(fileUrl.fsPath.indexOf(vscode.workspace.rootPath) < 0) {
+		vscode.window.showErrorMessage("Ftp-sync: Selected file is not a part of the workspace.");
+		return;
+	}
+
+	var config = ftpconfig.getConfig();
+	if(isIgnored(config.ignore, fileUrl.fsPath)) {
+		vscode.window.showErrorMessage("Ftp-sync: Selected file is ignored.");
+		return;
+	}
+
+	var fileName = path.basename(fileUrl.fsPath);
+	var uploadingStatus = vscode.window.setStatusBarMessage("Ftp-sync: Uploading " + fileName + " to FTP server...");
+
+	getFtpSync().uploadFile(fileUrl.fsPath, vscode.workspace.rootPath, function(err) {
+		uploadingStatus.dispose();
+		if(err)
+			vscode.window.showErrorMessage("Ftp-sync: Uploading " + fileName + " failed: " + err);
+		else
+			vscode.window.setStatusBarMessage("Ftp-sync: " + fileName + " uploaded successfully!", STATUS_TIMEOUT);
+	})
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "onCommand:extension.ftpsyncdownload",
     "onCommand:extension.ftpsynccommit",
     "onCommand:extension.ftpsyncsingle",
+    "onCommand:extension.ftpsyncuploadselected",
     "workspaceContains:.vscode/ftp-sync.json"
   ],
   "main": "./extension",
@@ -49,8 +50,20 @@
       {
         "command": "extension.ftpsyncsingle",
         "title": "Ftp-sync: Sync current file to Remote"
+      },
+      {
+        "command": "extension.ftpsyncuploadselected",
+        "title": "Ftp-sync: Upload File"
       }
-    ]
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "extension.ftpsyncuploadselected",
+          "group": "extension"
+        }
+      ]
+    }
   },
   "devDependencies": {
     "vscode": "0.10.x"


### PR DESCRIPTION
I added a context-item (right click on the file in the sidebar) that will allow the user to upload a single file (sometimes useful with images and other non-editable assets), also proposed in this issue: #53

The code is basically a clone of the on-save.js module, it does all the same checks.

PS. i'm aware of the similarity with this other pull request #77, but i find that not having to open a file to upload it could be a more viable solution in some contexts.
PPS. i'm also probably going to add other context menu items like upload a directory or download from remote to single files/directories which are features that i need/use all the time in other IDEs