### PR TITLE
Improve Error handling around parsing config file

### DIFF
--- a/modules/ftp-config.js
+++ b/modules/ftp-config.js
@@ -29,7 +29,15 @@ module.exports = {
 	},
 	getConfig: function() {
 		var configjson = fs.readFileSync(this.getConfigPath()).toString();
-		return _.defaults(JSON.parse(configjson), this.defaultConfig);
+		var configObject;
+
+		try {
+			configObject = JSON.parse(configjson);
+		}
+		catch (err){
+			vscode.window.showErrorMessage("Ftp-sync: Config file is not a valid JSON document. - " + err.message);
+		}
+		return _.defaults(configObject, this.defaultConfig);
 	},
 	validateConfig: function() {
 		if(!fs.existsSync(this.getConfigPath())) {


### PR DESCRIPTION
This change improves handling around invalid JSON in the config file. If the JSON is invalid, it returns the default config and throws an error to the user describing the issue. 

Previously you'd just get a non-helpful error saying that the command ftpsync failed. 
