### PR TITLE
Rudimentary ssh-agent support:

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Initializes a default FTP-Sync configuration file in the `.vscode` directory. Op
 - debug - Specifies whether to display debug information in an ftp-sync Output window. The default is `false`.
 - privateKeyPath - Specifies the path to the private key for SFTP. The default is `null`.
 - passphrase - Specifies the passphrase to use with the private key for SFTP. The default is `null`.
+- agent - Specifies the ssh-agent to use for SFTP. The default is `null`.
 - ignore - An array of escaped regular expression strings specifying paths to ignore. If a path matches any of these regular expressions then it will not be included in the sync. Default values are `"\\.git"`, `"\\.vscode"` and `".DS_Store"`.
 - "generatedFiles": { 
     * "uploadOnSave": true,

--- a/modules/ftp-config.js
+++ b/modules/ftp-config.js
@@ -28,6 +28,7 @@ module.exports = {
         debug: false,
         privateKeyPath: null,
         passphrase: null,
+		agent: null,
 		ignore: ["\\.vscode","\\.git","\\.DS_Store"],
 		generatedFiles: {
 			uploadOnSave: false,
@@ -77,6 +78,7 @@ module.exports = {
             protocol: config.protocol || "ftp",
             privateKeyPath: config.privateKeyPath,
             passphrase: config.passphrase,
+			agent: config.agent,
 			generatedFiles: config.generatedFiles,
             debug: config.debug ? function(msg) {
                 output(msg);

--- a/modules/sftp-wrapper.js
+++ b/modules/sftp-wrapper.js
@@ -22,7 +22,8 @@ module.exports = function() {
             username: ftpConfig.user,
             password: ftpConfig.password,
             privateKey: privateKey,
-            passphrase: ftpConfig.passphrase
+            passphrase: ftpConfig.passphrase,
+            agent: ftpConfig.agent
         });
     }
     


### PR DESCRIPTION
This adds minimal support for ssh-agent, addressing issue #35.  It passes the agent option from the configuration file up to the ssh2 library.

An example configuration (in addition to other options):

    "host": "my.ssh.server",
    "port": 22,
    "username": "username",
    "protocol": "sftp",
    "agent": "SSH_AGENT",

where `SSH_AGENT` is either `paegent` on Windows, or the contents of the `SSH_AUTH_SOCK` environment variable on Linux or macOS (see the documentation of ssh2 for details). When using the agent, there is no need to specify the password, passphrase or private key path. 