### PR TITLE
Fixes incorrect path for ignore of remote sync.

### DIFF
--- a/modules/sync-helper.js
+++ b/modules/sync-helper.js
@@ -62,7 +62,7 @@ var listRemoteFiles = function(remotePath, callback, originalRemotePath, options
 		
 		remoteFiles.forEach(function(fileInfo) {
 			//when listing remoteFiles by onPrepareRemoteProgress, ignore remoteFiles
-			if (isIgnored(ftpConfig.ignore, path.join(options.remotePath, fileInfo.name))) return;
+			if (isIgnored(ftpConfig.ignore, path.join(remotePath, fileInfo.name))) return;
 
 			if(fileInfo.name == "." || fileInfo.name == "..") return;
 			var remoteItemPath = upath.toUnix(path.join(remotePath, fileInfo.name));


### PR DESCRIPTION
`remotePath` is the current directory (and, child directories) where `fileInfo` is actually contained and should be used rather than the `options.remotePath`. This allows ignoring paths of specific nested files which is currently impossible.

Fixes #162