### PR TITLE
Fix config secureOptions being ignored

### DIFF
--- a/modules/ftp-config.js
+++ b/modules/ftp-config.js
@@ -76,6 +76,7 @@ module.exports = {
 			ignore: config.ignore,
 			passive: config.passive,
 			secure: config.secure,
+			secureOptions: config.secureOptions,
 			protocol: config.protocol || "ftp",
 			privateKeyPath: config.privateKeyPath,
 			passphrase: config.passphrase,


### PR DESCRIPTION
Fix for #194 by allowing `secureOptions` in the config file which will then be passed by this extension to `ftp` and finally to `tls`.