### PR TITLE
Introduced separate store to store syncOption

### DIFF
--- a/modules/command-helper.js
+++ b/modules/command-helper.js
@@ -1,5 +1,7 @@
 var vscode = require('vscode');
 
+var _store = new WeakMap();
+
 module.exports = {
 	executeSync: function(syncHelper, sync, options) {
 		var syncInfoMessage = null;
@@ -16,5 +18,10 @@ module.exports = {
 			else
 				vscode.window.setStatusBarMessage("Ftp-sync: sync-complete!", STATUS_TIMEOUT);
 		})
+	},
+	getStore: function(key) {
+		if (!_store.has(key))
+			_store.set(key, {});
+		return _store.get(key);
 	}
 }

--- a/modules/commit-command.js
+++ b/modules/commit-command.js
@@ -6,13 +6,17 @@ var helper = require('./command-helper');
 module.exports = function(getSyncHelper) {
 
 	if(!vscode.window.activeTextEditor || 
-	   !vscode.window.activeTextEditor.document ||
-	   !vscode.window.activeTextEditor.document.syncOptions) {
-		vscode.window.showErrorMessage("Ftp-sync: no operations list to commit. Run sync first.");
+	   !vscode.window.activeTextEditor.document) {
+		vscode.window.showErrorMessage("Ftp-sync: no sync-summary found. Run sync again and don\'t close the sync-summary file.");
 		return;
 	}
 	
-	var options = vscode.window.activeTextEditor.document.syncOptions;
+    var options = helper.getStore(vscode.window.activeTextEditor.document).syncOptions;
+    if (!options) {
+		vscode.window.showErrorMessage("Ftp-sync: no operations list to commit. Run sync first.");
+		return;
+    }
+
 	var syncJson = vscode.window.activeTextEditor.document.getText();
     
     var jsonCorrect = true;

--- a/modules/sync-command.js
+++ b/modules/sync-command.js
@@ -29,7 +29,7 @@ module.exports = function(isUpload, getSyncHelper) {
 						editBuilder.insert(new vscode.Position(0, 0), syncJson);
 					});
 				});
-				vscode.window.activeTextEditor.document.syncOptions = options;
+				helper.getStore(vscode.window.activeTextEditor.document).syncOptions = options;
 			}, function(err) {
             vscode.window.showErrorMessage("Ftp-sync: sync error: " + err)
             })

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       {
         "command": "extension.ftpsyncdownloadselected",
         "title": "Ftp-sync: Download File"
-       }
+      }
     ],
     "menus": {
       "explorer/context": [


### PR DESCRIPTION
Closes #165 

It's currently unable to set custom property at `vscode.window.activeTextEditor.document`, to which `syncOption` was set to communicate between Review and Commit command. We need to find different communication method.

Here I introduced WeakMap `_store` for suc. Instead of setting property directly on ([TextDocument](https://code.visualstudio.com/docs/extensionAPI/vscode-api#TextDocument)), It uses `_store`.

Issue 165 is solved this way, tested on MBP 2016

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lukasz-wronski/vscode-ftp-sync/200)
<!-- Reviewable:end -->
