### PR TITLE
fix for broken ignore and allow regex

### DIFF
--- a/modules/is-ignored.js
+++ b/modules/is-ignored.js
@@ -5,10 +5,6 @@ module.exports = function(path, patterns_allowed, patterns_ignored) {
 
 	var n = 0, skip = false;
 	if (patterns_allowed.length > 0) {
-		patterns_allowed = patterns_allowed.map(function(p) {
-			return upath.toUnix(p);
-		});
-
 		skip = true;
 		for (n = 0; n < patterns_allowed.length; n++){
 			if ((new RegExp(patterns_allowed[n])).test(path)) {
@@ -18,9 +14,6 @@ module.exports = function(path, patterns_allowed, patterns_ignored) {
 		}
 	}
 
-	patterns_ignored = patterns_ignored.map(function(p) {
-		return upath.toUnix(p);
-	});
 	for (n = 0; n < patterns_ignored.length; n++){
 		if ((new RegExp(patterns_ignored[n])).test(path)) {
 			skip = true;


### PR DESCRIPTION
The ignore and allow regex patterns are treated like unix paths. The call to upath.toUnix() converts one or more \ characters to / and completely brakes regex.