### PR TITLE
Fixed broken unicode file names

### DIFF
--- a/modules/ftp-wrapper.js
+++ b/modules/ftp-wrapper.js
@@ -30,7 +30,13 @@ module.exports = function() {
     }
     
     self.list = function(path, callback) {
-        ftp.list(path, callback);
+        ftp.list(path, function(err, remoteFiles) {
+            for(var fileInfo of remoteFiles) {
+                fileInfo.name = decodeURIComponent(escape(fileInfo.name))
+            }
+            if(callback)
+                callback(err, remoteFiles)
+        });
     }
     
     self.get = function(remotePath, localPath, callback) {


### PR DESCRIPTION
Because files with unicode characters such as 'ä' or 'ê' in their name did not get encoded correctly you couldn't download them. This is a simple fix for this problem.

Related Issues:
https://github.com/lukasz-wronski/vscode-ftp-sync/issues/41